### PR TITLE
Version upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,24 +6,26 @@ Idiomatic Purescript bindings for the Facebook SDK
 ### Disclaimer: this project is a work in progress
 
 Currently supported methods:
-1. [FB.init](https://developers.facebook.com/docs/javascript/reference/FB.init/v2.10)
-1. [FB.loginStatus](https://developers.facebook.com/docs/reference/javascript/FB.getLoginStatus/v2.10)
-1. [FB.login](https://developers.facebook.com/docs/reference/javascript/FB.login/v2.10)
-1. [FB.logout](https://developers.facebook.com/docs/reference/javascript/FB.logout/v2.10)
+1. [FB.init](https://developers.facebook.com/docs/javascript/reference/FB.init/v3.1)
+1. [FB.loginStatus](https://developers.facebook.com/docs/reference/javascript/FB.getLoginStatus/v3.1)
+1. [FB.login](https://developers.facebook.com/docs/reference/javascript/FB.login/v3.1)
+1. [FB.logout](https://developers.facebook.com/docs/reference/javascript/FB.logout/v3.1)
 
 Init Facebook SDK & retrieve a current login status:
 
 ``` purescript
-import Control.Monad.Aff (Aff)
-import Control.Monad.Aff.Console (logShow)
-import Control.Monad.Eff.Console (CONSOLE)
+import Prelude
+
+import Effect.Aff (Aff)
+import Effect.Class (liftEffect)
+import Effect.Console (logShow)
 import Facebook.Sdk (init, loginStatus, defaultConfig) as FB
 
-initFacebook :: ∀ e. Aff (console :: CONSOLE | e) Unit
+initFacebook :: Aff Unit
 initFacebook = do
-  sdk <- FB.init $ defaultConfig "1234567890" -- your app id
+  sdk <- FB.init $ FB.defaultConfig "1234567890" -- your app id
   info <- FB.loginStatus sdk
-  logShow info
+  liftEffect $ logShow info
 ```
 
 Outputs to the console:

--- a/bower.json
+++ b/bower.json
@@ -17,14 +17,15 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^3.1.0",
-    "purescript-console": "^3.0.0",
-    "purescript-aff": "^3.1.0",
-    "purescript-foreign": "^4.0.1",
-    "purescript-foreign-generic": "^5.0.0",
-    "purescript-errors": "^3.0.0"
+    "purescript-prelude": "^4.1.0",
+    "purescript-console": "^4.2.0",
+    "purescript-aff": "^5.1.0",
+    "purescript-foreign": "^5.0.0",
+    "purescript-errors": "^4.0.1",
+    "purescript-effect": "^2.0.0",
+    "purescript-foreign-generic": "^7.0.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0"
+    "purescript-psci-support": "^4.0.0"
   }
 }

--- a/src/Facebook/Sdk.js
+++ b/src/Facebook/Sdk.js
@@ -43,20 +43,26 @@ exports._api = function(fb, path, method, params, callback) {
 exports._init = function(callback) {
   return function(fbConfig) {
     return function() { // returns an effect
-      window.fbAsyncInit = function() {
-        FB.init(fbConfig);
-        FB.AppEvents.logPageView();
-        callback(FB)(); // callback itself returns an effect
+      // Check if FB is already initialized
+      if (window.isFBLoaded || window.FB && typeof window.FB === 'object') {
+        callback(window.FB)();
+      } else {
+        window.fbAsyncInit = function() {
+          window.FB.init(fbConfig);
+          window.FB.AppEvents.logPageView();
+          window.isFBLoaded = true;
+          callback(window.FB)(); // callback itself returns an effect
+        };
+        (function(d, s, id){
+          var js, fjs = d.getElementsByTagName(s)[0];
+          if (d.getElementById(id)) {return;}
+          js = d.createElement(s);
+          js.id = id;
+          var debug = fbConfig['debug'] ? "/debug" : "";
+          js.src = "//connect.facebook.net/" + fbConfig['locale'] + "/sdk" + debug + ".js";
+          fjs.parentNode.insertBefore(js, fjs);
+        }(window.document, 'script', 'facebook-jssdk'));
       };
-      (function(d, s, id){
-        var js, fjs = d.getElementsByTagName(s)[0];
-        if (d.getElementById(id)) {return;}
-        js = d.createElement(s);
-        js.id = id;
-        var debug = fbConfig['debug'] ? "/debug" : "";
-        js.src = "//connect.facebook.net/" + fbConfig['locale'] + "/sdk" + debug + ".js";
-        fjs.parentNode.insertBefore(js, fjs);
-      }(window.document, 'script', 'facebook-jssdk'));
     }
   }
 }


### PR DESCRIPTION
Make compatible with purescript >= `v0.12.0`.

Also:
- upgrade version of default Facebook sdk from `v2.10` to `v3.1`.
- in `Sdk.js`, check if the `FB` object  already exists before loading and initializing it (this gives the option of loading the Facebook sdk outside of this package)

